### PR TITLE
Fix GitHub build actions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "the-boring-utilities-app",
-  "version": "0.0.0-beta",
-  "authors": [
-    "Tulza <https://github.com/tulza>"
-  ],
-  "license": "GPL-3.0",
-   "scripts": {
+    "name": "the-boring-utilities-app",
+    "version": "0.0.0-beta",
+    "authors": [
+        "Tulza <https://github.com/tulza>"
+    ],
+    "license": "GPL-3.0",
+    "scripts": {
         "dev": "next dev --turbo",
         "build": "next build",
         "analyze": "ANALYZE=true next build",
@@ -23,7 +23,7 @@
         "payload": "cross-env PAYLOAD_CONFIG_PATH=src/payload.config.ts payload",
         "generate:type": "pnpm run payload generate:types"
     },
-  "dependencies": {
+    "dependencies": {
         "@payloadcms/db-postgres": "^3.1.1",
         "@payloadcms/next": "^3.1.1",
         "@payloadcms/richtext-lexical": "^3.1.1",
@@ -56,6 +56,7 @@
         "prettier": "^3.3.3",
         "prettier-plugin-tailwindcss": "^0.6.8",
         "tailwindcss": "^3.4.1",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5",
         "typescript-eslint": "^8.13.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.15
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
       typescript:
         specifier: ^5
         version: 5.7.2
@@ -2385,6 +2388,11 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
 
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3397,6 +3405,10 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -6003,6 +6015,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
+  json5@2.2.3: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.8
@@ -7188,6 +7202,12 @@ snapshots:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 

--- a/src/app/(routes)/layout.tsx
+++ b/src/app/(routes)/layout.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 
 import "./globals.css";
 
+import { geistMono, geistSans } from "@fonts/GeistFont";
+
 export const metadata: Metadata = {
     title: "The boring utilities app",
     description:

--- a/src/collections/Catalogue.ts
+++ b/src/collections/Catalogue.ts
@@ -1,6 +1,5 @@
+import { SLUG } from "@libs/consts/slug";
 import type { CollectionConfig } from "payload";
-
-import { SLUG } from "@/libs/consts/slug";
 
 export const Catalogue: CollectionConfig = {
     slug: SLUG.CATALOGUE,

--- a/src/components/loader/Intro.tsx
+++ b/src/components/loader/Intro.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import React from "react";
+import { easeOutQuad } from "@libs/ease";
 import { motion, Variants } from "framer-motion";
-
-import { easeOutQuad } from "@/libs/ease";
 
 const Intro = ({ children }: { children: React.ReactNode }) => {
     return (

--- a/src/components/text/AnimatedText.tsx
+++ b/src/components/text/AnimatedText.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import React from "react";
+import { textVariantDefault } from "@data/variants/text";
+import { cn } from "@libs/utils";
+import { type HTMLAttributeNoMotion } from "@typings/motion";
 import { motion, Variants } from "motion/react";
 
-import { textVariantDefault } from "@/data/variants/text";
-import { cn } from "@/libs/utils";
-import { HTMLAtrributeNoMotion } from "@/types/motion";
-
-interface TextProps extends HTMLAtrributeNoMotion<"p"> {
+interface TextProps extends HTMLAttributeNoMotion<"p"> {
     text: string;
     type?: "char" | "word";
     variants?: Variants;

--- a/src/data/variants/text.ts
+++ b/src/data/variants/text.ts
@@ -1,4 +1,4 @@
-import { easeOutQuad } from "@/libs/ease";
+import { easeOutQuad } from "@libs/ease";
 
 export const textVariantDefault = {
     initial: {

--- a/src/types/motion.ts
+++ b/src/types/motion.ts
@@ -1,3 +1,3 @@
 import { HTMLMotionProps, MotionProps } from "framer-motion";
 
-export type HTMLAtrributeNoMotion<T extends keyof HTMLElementTagNameMap> = Omit<HTMLMotionProps<T>, keyof MotionProps>;
+export type HTMLAttributeNoMotion<T extends keyof HTMLElementTagNameMap> = Omit<HTMLMotionProps<T>, keyof MotionProps>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
             "@fonts/*": ["./src/fonts/*"],
             "@hooks/*": ["./src/hooks/*"],
             "@libs/*": ["./src/libs/*"],
+            "@typings/*": ["./src/types/*"], // local types
             "@payload-config": ["./src/payload.config.ts"]
         },
         "target": "ES2022"


### PR DESCRIPTION
before, during the GitHub action build time, the action couldn't parse what the path alias are and therefore the build would automatically fail.

### Fix:
Github action wasn't detecting path alias since`tsconfig-paths` package wasn't available.

**minor fix(s):**
- swap all the `@/route` with their appropriate alias.

closes #2 
